### PR TITLE
Anisotropic polarizabilities

### DIFF
--- a/source/analyze.f
+++ b/source/analyze.f
@@ -1183,12 +1183,14 @@ c
                   header = .false.
                   write (iout,740)
   740             format (/,' Dipole Polarizability Parameters :',
-     &                    //,10x,'Atom Number',5x,'Alpha',5x,'Damp',
+     &                    //,9x,'Atom Number',4x,'Alpha xx',2x,
+     &                       'Alpha yy',2x,'Alpha zz',3x,'Damp',
      &                       6x,'Polarization Group',/)
                end if
-               write (iout,750)  i,ia,polarity(i),thole(i),
+               write (iout,750)  i,ia,polarity(1,i),polarity(2,i),
+     &                            polarity(3,i), thole(i),
      &                           (ip11(j,ia),j=1,np11(ia))
-  750          format (i6,3x,i6,6x,f10.4,f9.3,3x,120i6)
+  750          format (i6,3x,i6,6x,3f10.4,f9.3,3x,20i6)
             end if
          end do
       end if
@@ -2403,10 +2405,12 @@ c
                   header = .false.
                   write (iout,730)
   730             format (/,' Dipole Polarizability Parameters :',
-     &                    //,10x,'Atom Number',9x,'Alpha',8x,
+     &                    //,10x,'Atom Number',9x,'Alpha xx',8x,
+     &                       'Alpha yy',4x, 'Alpha zz',4x,
      &                       'Polarization Group',/)
                end if
-               write (iout,740)  i,ia,polarity(i),
+               write (iout,740)  i,ia,polarity(1,i),polarity(2,i),
+     &                                polarity(3,i),
      &                           (ip11(j,ia),j=1,np11(ia))
   740          format (i6,3x,i6,10x,f10.4,5x,20i6)
             end if

--- a/source/epolar.f
+++ b/source/epolar.f
@@ -1628,7 +1628,7 @@ c
       use potent
       use units
       implicit none
-      integer i,j,ii
+      integer i,j,ii,m
       real*8 e,f,fi,term
       real*8 xd,yd,zd
       real*8 xu,yu,zu
@@ -1660,20 +1660,17 @@ c
 c     OpenMP directives for the major loop structure
 c
 !$OMP PARALLEL default(private)
-!$OMP& shared(npole,polarity,f,uind,udirp,ep)
+!$OMP& shared(npole,rpolarityinv,f,uind,udirp,ep)
 !$OMP DO reduction(+:ep) schedule(guided)
 c
 c     get polarization energy via induced dipoles times field
 c
       do i = 1, npole
-         if (polarity(i) .ne. 0.0d0) then
-            fi = f / polarity(i)
-            e = 0.0d0
-            do j = 1, 3
-               e = fi * uind(j,i) * udirp(j,i)
-               ep = ep + e
+         do j = 1, 3
+            do m = 1, 3
+              ep = ep + f * uind(j,i) * udirp(m,i) * rpolarityinv(m,j,i)
             end do
-         end if
+         end do
       end do
 c
 c     OpenMP directives for the major loop structure

--- a/source/epolar.f
+++ b/source/epolar.f
@@ -1937,7 +1937,8 @@ c
             e = e + fuind(k,i)*fphi(k+1,i)
          end do
       end do
-      e = 0.5d0 * f * e
+c      e = 0.5d0 * f * e
+      e = 0.5d0 * e
       ep = ep + e
 c
 c     perform deallocation of some local arrays

--- a/source/epolar.f
+++ b/source/epolar.f
@@ -1759,7 +1759,7 @@ c
       integer m1,m2,m3
       integer ntot,nff
       integer nf1,nf2,nf3
-      real*8 e,r1,r2,r3
+      real*8 e,r1,r2,r3,f
       real*8 h1,h2,h3
       real*8 volterm,denom
       real*8 hsq,expterm
@@ -1769,6 +1769,7 @@ c
       real*8, allocatable :: fuind(:,:)
       real*8, allocatable :: fuinp(:,:)
 c
+      f = electric / dielec
 c
 c     return if the Ewald coefficient is zero
 c
@@ -1890,7 +1891,7 @@ c
          call fphi_mpole (fphi)
          do i = 1, npole
             do j = 1, 20
-               fphi(j,i) = electric * fphi(j,i)
+               fphi(j,i) = f * fphi(j,i)
             end do
          end do
       end if
@@ -1926,7 +1927,7 @@ c
       if (.not. use_bounds) then
          expterm = 0.5d0 * pi / xbox
          struc2 = qgrid(1,1,1,1)**2 + qgrid(2,1,1,1)**2
-         e = 0.5d0 * electric * expterm * struc2
+         e = 0.5d0 * f * expterm * struc2
          ep = ep + e
       end if
 c
@@ -1939,7 +1940,7 @@ c
             e = e + fuind(k,i)*fphi(k+1,i)
          end do
       end do
-      e = 0.5d0 * e
+      e = 0.5d0 * f * e
       ep = ep + e
 c
 c     perform deallocation of some local arrays

--- a/source/epolar3.f
+++ b/source/epolar3.f
@@ -1923,7 +1923,7 @@ c
       use potent
       use units
       implicit none
-      integer i,j,ii
+      integer i,j,ii,m
       real*8 e,f,fi,term
       real*8 xd,yd,zd
       real*8 xu,yu,zu
@@ -1977,12 +1977,15 @@ c
 c     get polarization energy via induced dipoles times field
 c
       do i = 1, npole
-         if (polarity(i) .ne. 0.0d0) then
-            ii = ipole(i)
-            fi = f / polarity(i)
+         ii = ipole(i)
+         if (polarity(1,i) .ne. 0.0d0 .or.
+     &       polarity(2,i) .ne. 0.0d0 .or.
+     &       polarity(3,i) .ne. 0.0d0) then
             e = 0.0d0
             do j = 1, 3
-               e = e + fi*uind(j,i)*udirp(j,i)
+               do m = 1, 3
+                 e = e + f * uind(j,i) * udirp(m,i)*rpolarityinv(m,j,i)
+               end do
             end do
             nep = nep + 1
             ep = ep + e
@@ -1997,11 +2000,13 @@ c
                   write (iout,20)
    20             format (/,' Individual Dipole Polarization',
      &                       ' Interactions :',
-     &                    //,' Type',9x,'Atom Name',24x,'Alpha',
+     &                    //,' Type',9x,'Atom Name',24x,'Alpha xx',
+     &                       'Alpha yy', 8x, 'Alpha zz',
      &                       8x,'Energy',/)
                end if
-               write (iout,30)  ii,name(ii),polarity(i),e
-   30          format (' Polar',5x,i7,'-',a3,16x,2f14.4)
+               write (iout,30)  ii,name(ii),polarity(1,i),polarity(2,i),
+     &                              polarity(3,i), e
+   30          format (' Polar',5x,i7,'-',a3,16x,4f14.4)
             end if
          end if
       end do

--- a/source/final.f
+++ b/source/final.f
@@ -629,7 +629,10 @@ c     deallocation of global arrays from module polar
 c
       if (allocated(copt))  deallocate (copt)
       if (allocated(copm))  deallocate (copm)
+      if (allocated(is_aniso))  deallocate (is_aniso)
       if (allocated(polarity))  deallocate (polarity)
+      if (allocated(rpolarity))  deallocate (rpolarity)
+      if (allocated(rpolarityinv))  deallocate (rpolarityinv)
       if (allocated(thole))  deallocate (thole)
       if (allocated(pdamp))  deallocate (pdamp)
       if (allocated(udir))  deallocate (udir)

--- a/source/initial.f
+++ b/source/initial.f
@@ -15,12 +15,6 @@ c
 c     "initial" sets up original values for some parameters and
 c     variables that might not otherwise get initialized
 c
-c     note calls below to the "kmp_set" routines are for use with
-c     the Intel compiler, but must be commented for other compilers;
-c     alternatively, these values can be set via the KMP_STACKSIZE
-c     and KMP_BLOCKTIME environment variables
-c
-c
       subroutine initial
       use sizes
       use align
@@ -48,7 +42,6 @@ c
       use scales
       use sequen
       use socket
-      use virial
       use warp
       use zclose
       implicit none
@@ -82,11 +75,13 @@ c
 !$    call omp_set_num_threads (nthread)
 !$    call omp_set_nested (.true.)
 c
-c     Intel compiler extensions to OpenMP standard, 268435456 bytes is
-c     2**28 bytes, or 256 MB; comment these lines for other compilers
+c     Intel compiler extensions to OpenMP standard
 c
-c!$   call kmp_set_stacksize_s (268435456)
-c!$   call kmp_set_blocktime (0)
+c     commented out for gfortran compiler
+c#ifdef __INTEL_COMPILER
+c!$    call kmp_set_stacksize_s (2**28)
+c!$    call kmp_set_blocktime (0)
+c#endif
 c
 c     values of machine precision constants
 c
@@ -151,15 +146,11 @@ c     flag for use of atom groups
 c
       use_group = .false.
 c
-c     flags for use of periodic boundaries
+c     flags for periodic boundaries
 c
       use_bounds = .false.
       use_replica = .false.
       use_polymer = .false.
-c
-c     flag for use of internal virial
-c
-      use_virial = .true.
 c
 c     default values for unitcell dimensions
 c

--- a/source/initprm.f
+++ b/source/initprm.f
@@ -189,7 +189,7 @@ c
       if (.not. allocated(eps4))  allocate (eps4(maxtyp))
       if (.not. allocated(reduct))  allocate (reduct(maxtyp))
       if (.not. allocated(chg))  allocate (chg(maxtyp))
-      if (.not. allocated(polr))  allocate (polr(maxtyp))
+      if (.not. allocated(polr))  allocate (polr(3,maxtyp))
       if (.not. allocated(athl))  allocate (athl(maxtyp))
       if (.not. allocated(pgrp))  allocate (pgrp(maxval,maxtyp))
 c
@@ -209,7 +209,9 @@ c
          eps4(i) = 0.0d0
          reduct(i) = 0.0d0
          chg(i) = 0.0d0
-         polr(i) = 0.0d0
+         do j = 1, 3
+            polr(j,i) = 0.0d0
+         enddo
          athl(i) = 0.0d0
          do j = 1, maxval
             pgrp(j,i) = 0

--- a/source/kpolr.f
+++ b/source/kpolr.f
@@ -20,7 +20,7 @@ c
       module kpolr
       implicit none
       integer, allocatable :: pgrp(:,:)
-      real*8, allocatable :: polr(:)
+      real*8, allocatable :: polr(:,:)
       real*8, allocatable :: athl(:)
       save
       end

--- a/source/mdsave.f
+++ b/source/mdsave.f
@@ -242,7 +242,9 @@ c
          write (iind,280)  n,title(1:ltitle)
   280    format (i6,2x,a)
          do i = 1, npole
-            if (polarity(i) .ne. 0.0d0) then
+            if (polarity(1,i) .ne. 0.0d0 .or.
+     &          polarity(2,i) .ne. 0.0d0 .or.
+     &          polarity(3,i) .ne. 0.0d0) then
                k = ipole(i)
                write (iind,290)  k,name(k),(debye*uind(j,i),j=1,3)
   290          format (i6,2x,a3,3f12.6)

--- a/source/mutate.f
+++ b/source/mutate.f
@@ -190,7 +190,9 @@ c
          end do
          do i = 1, npolar
             if (mut(i)) then
-               polarity(i) = polarity(i) * elambda
+               do j = 1, 3
+                  polarity(j,i) = polarity(j,i) * elambda
+               end do
             end if
          end do
       end if

--- a/source/polar.f
+++ b/source/polar.f
@@ -19,7 +19,10 @@ c     coptmax   maximum coefficient order for OPT dipole extrapolation
 c     optlevel  current OPT order for reciprocal potential and field
 c     copt      coefficients for OPT total induced dipole moments
 c     copm      coefficients for OPT incremental induced dipole moments
-c     polarity  dipole polarizability for each multipole site (Ang**3)
+c     polarity  anisotropic dipole polarizability for each multipole site (body frame, Ang**3)
+c     rpolarity anisotropic dipole polarizability for each multipole site (lab frame, Ang**3)
+c     rpolarityinv inverted anisotropic dipole polarizability for each multipole site (lab frame, Ang**3)
+c     is_aniso   whether each polarizabile site is anisotropic or not
 c     thole     Thole polarizability damping value for each site
 c     pdamp     value of polarizability scale factor for each site
 c     udir      direct induced dipole components at each multipole site
@@ -49,7 +52,10 @@ c
       integer optlevel
       real*8, allocatable :: copt(:)
       real*8, allocatable :: copm(:)
-      real*8, allocatable :: polarity(:)
+      real*8, allocatable :: rpolarity(:,:,:)
+      real*8, allocatable :: rpolarityinv(:,:,:)
+      real*8, allocatable :: polarity(:,:)
+      logical, allocatable :: is_aniso(:)
       real*8, allocatable :: thole(:)
       real*8, allocatable :: pdamp(:)
       real*8, allocatable :: udir(:,:)

--- a/source/polarize.f
+++ b/source/polarize.f
@@ -60,7 +60,7 @@ c
       end if
       addu = 0.0d0
       do i = 1, npole
-         addu = polarity(i) + addu
+         addu = (polarity(1,i)+polarity(2,i)+polarity(3,i))/3.0d0 + addu
       end do
       fstr = ' Additive Total Polarizability :    '
       if (nmol .eq. 1)  fstr = ' Additive Molecular Polarizability :'
@@ -190,7 +190,7 @@ c
       real*8 a,b,sum
       real*8 umol(3)
       real*8 exfield(3)
-      real*8, allocatable :: poli(:)
+      real*8, allocatable :: poli(:,:)
       real*8, allocatable :: field(:,:)
       real*8, allocatable :: rsd(:,:)
       real*8, allocatable :: zrsd(:,:)
@@ -203,13 +203,13 @@ c     set induced dipoles to polarizability times external field
 c
       do i = 1, npole
          do j = 1, 3
-            uind(j,i) = polarity(i) * exfield(j)
+            uind(j,i) = polarity(j,i) * exfield(j)
          end do
       end do
 c
 c     perform dynamic allocation of some local arrays
 c
-      allocate (poli(npole))
+      allocate (poli(3,npole))
       allocate (field(3,npole))
       allocate (rsd(3,npole))
       allocate (zrsd(3,npole))
@@ -226,10 +226,10 @@ c
          polmin = 0.00000001d0
          call ufield (field)
          do i = 1, npole
-            poli(i) = max(polmin,polarity(i))
             do j = 1, 3
+               poli(j,i) = max(polmin,polarity(j,i))
                rsd(j,i) = field(j,i)
-               zrsd(j,i) = rsd(j,i) * poli(i)
+               zrsd(j,i) = rsd(j,i) * poli(j,i)
                conj(j,i) = zrsd(j,i)
             end do
          end do
@@ -248,7 +248,7 @@ c
             do i = 1, npole
                do j = 1, 3
                   uind(j,i) = vec(j,i)
-                  vec(j,i) = conj(j,i)/poli(i) - field(j,i)
+                  vec(j,i) = conj(j,i)/poli(j,i) - field(j,i)
                end do
             end do
             a = 0.0d0
@@ -269,7 +269,7 @@ c
             b = 0.0d0
             do i = 1, npole
                do j = 1, 3
-                  zrsd(j,i) = rsd(j,i) * poli(i)
+                  zrsd(j,i) = rsd(j,i) * poli(j,i)
                   b = b + rsd(j,i)*zrsd(j,i)
                end do
             end do

--- a/source/poledit.f
+++ b/source/poledit.f
@@ -506,7 +506,7 @@ c
       use mpole
       use polar
       implicit none
-      integer i,j,k,m,ixyz
+      integer i,j,jj,k,m,ixyz
       integer atmnum,size
       integer freeunit
       real*8 xi,yi,zi
@@ -593,7 +593,7 @@ c
 c
 c     perform dynamic allocation of some global arrays
 c
-      if (.not. allocated(polarity))  allocate (polarity(n))
+      if (.not. allocated(polarity))  allocate (polarity(3,n))
       if (.not. allocated(thole))  allocate (thole(n))
       if (.not. allocated(pdamp))  allocate (pdamp(n))
       if (.not. allocated(ipole))  allocate (ipole(n))
@@ -605,43 +605,67 @@ c
       do i = 1, n
          atmnum = atomic(i)
          mass(i) = 1.0d0
-         polarity(i) = 0.0d0
+         do j = 1, 3
+            polarity(j,i) = 0.0d0
+         end do
          thole(i) = 0.39d0
          if (atmnum .eq. 1) then
             mass(i) = 1.008d0
-            polarity(i) = 0.496d0
+            do j = 1, 3
+               polarity(j,i) = 0.496d0
+            end do
          else if (atmnum .eq. 5) then
             mass(i) = 10.810d0
-            polarity(i) = 1.600d0
+            do j = 1, 3
+               polarity(j,i) = 1.600d0
+            end do
          else if (atmnum .eq. 6) then
             mass(i) = 12.011d0
-            polarity(i) = 1.334d0
+            do j = 1, 3
+               polarity(j,i) = 1.334d0
+            end do
          else if (atmnum .eq. 7) then
             mass(i) = 14.007d0
-            polarity(i) = 1.073d0
+            do j = 1, 3
+               polarity(j,i) = 1.073d0
+            end do
          else if (atmnum .eq. 8) then
             mass(i) = 15.999d0
-            polarity(i) = 0.837d0
+            do j = 1, 3
+               polarity(j,i) = 0.837d0
+            end do
          else if (atmnum .eq. 9) then
             mass(i) = 18.998d0
-            polarity(i) = 0.507d0
+            do j = 1, 3
+               polarity(j,i) = 0.507d0
+            end do
          else if (atmnum .eq. 14) then
             mass(i) = 28.086d0
          else if (atmnum .eq. 15) then
             mass(i) = 30.974d0
-            polarity(i) = 1.828d0
+            do j = 1, 3
+               polarity(j,i) = 1.828d0
+            end do
          else if (atmnum .eq. 16) then
             mass(i) = 32.066d0
-            polarity(i) = 3.300d0
+            do j = 1, 3
+               polarity(j,i) = 3.300d0
+            end do
          else if (atmnum .eq. 17) then
             mass(i) = 35.453d0
-            polarity(i) = 2.500d0
+            do j = 1, 3
+               polarity(j,i) = 2.500d0
+            end do
          else if (atmnum .eq. 35) then
             mass(i) = 79.904d0
-            polarity(i) = 3.595d0
+            do j = 1, 3
+               polarity(j,i) = 3.595d0
+            end do
          else if (atmnum .eq. 53) then
             mass(i) = 126.904d0
-            polarity(i) = 5.705d0
+            do j = 1, 3
+               polarity(j,i) = 5.705d0
+            end do
          end if
       end do
 c
@@ -652,21 +676,29 @@ c
          if (atmnum .eq. 1) then
             j = i12(1,i)
             if (atomic(j).eq.6 .and. n12(j).eq.3) then
-               polarity(i) = 0.696d0
+               do jj = 1, 3
+                  polarity(jj,i) = 0.696d0
+               end do
                do k = 1, n12(j)
                   m = i12(k,j)
                   if (atomic(m).eq.8 .and. n12(m).eq.1) then
-                     polarity(i) = 0.494d0
+                     do jj = 1, 3
+                        polarity(jj,i) = 0.494d0
+                     end do
                   end if
                end do
             end if
          else if (atmnum .eq. 6) then
             if (n12(i) .eq. 3) then
-               polarity(i) = 1.75d0
+               do jj = 1, 3
+                  polarity(jj,i) = 1.75d0
+               end do
                do j = 1, n12(i)
                   k = i12(j,i)
                   if (atomic(k).eq.8 .and. n12(k).eq.1) then
-                     polarity(i) = 1.334d0
+                     do jj = 1, 3
+                        polarity(jj,i) = 1.334d0
+                     end do
                   end if
                end do
             end if
@@ -685,7 +717,8 @@ c
          if (thole(i) .eq. 0.0d0) then
             pdamp(i) = 0.0d0
          else
-            pdamp(i) = polarity(i)**sixth
+            pdamp(i) = ((polarity(1,i)+polarity(2,i)+polarity(3,i))
+     &                  /3.0d0)**sixth
          end if
       end do
       return
@@ -1487,15 +1520,17 @@ c
       write (iout,10)
    10 format (/,' Atomic Polarizabilities for Multipole Sites :')
       write (iout,20)
-   20 format (/,5x,'Atom',5x,'Name',7x,'Polarize',10x,'Thole',/)
+   20 format (/,5x,'Atom',5x,'Name',7x,'Polarize xx',7x,
+     &         'Polarize yy',7x,'Polarize zz',7x,'Thole',/)
       do ii = 1, n
          i = pollist(ii)
          if (i .eq. 0) then
             write (iout,30)  ii,name(ii)
    30       format (i8,6x,a3,12x,'--',13x,'--')
          else
-            write (iout,40)  ii,name(ii),polarity(i),thole(i)
-   40       format (i8,6x,a3,4x,f12.4,3x,f12.4)
+            write (iout,40)  ii,name(ii),polarity(1,i),
+     &            polarity(2,i),polarity(3,i),thole(i)
+   40       format (i8,6x,a3,4x,f12.4,3x,f12.4,3x,f12.4,3x,f12.4)
          end if
       end do
 c
@@ -1529,7 +1564,9 @@ c
          end if
          if (i .ne. 0) then
             change = .true.
-            polarity(i) = pol
+            do j = 1, 3
+               polarity(j,i) = pol
+            enddo
             thole(i) = thl
          end if
       end do
@@ -1540,15 +1577,17 @@ c
          write (iout,90)
    90    format (/,' Atomic Polarizabilities for Multipole Sites :')
          write (iout,100)
-  100    format (/,5x,'Atom',5x,'Name',7x,'Polarize',10x,'Thole',/)
+  100    format (/,5x,'Atom',5x,'Name',7x,'Polarize xx',7x,
+     &              'Polarize yy',7x,'Polarize zz',7x,'Thole',/)
          do ii = 1, n
             i = pollist(ii)
             if (i .eq. 0) then
                write (iout,110)  ii,name(ii)
   110          format (i8,6x,a3,12x,'--',13x,'--')
             else
-               write (iout,120)  ii,name(ii),polarity(i),thole(i)
-  120          format (i8,6x,a3,4x,f12.4,3x,f12.4)
+               write (iout,120)  ii,name(ii),polarity(1,i),
+     &                         polarity(2,i),polarity(3,i),thole(i)
+  120          format (i8,6x,a3,4x,f12.4,3x,f12.4,3x,f12.4,3x,f12.4)
             end if
          end do
       end if
@@ -1779,7 +1818,7 @@ c
       real*8 polmin,norm
       real*8 a,b,sum
       real*8, allocatable :: pscale(:)
-      real*8, allocatable :: poli(:)
+      real*8, allocatable :: poli(:,:)
       real*8, allocatable :: field(:,:)
       real*8, allocatable :: rsd(:,:)
       real*8, allocatable :: zrsd(:,:)
@@ -1795,7 +1834,7 @@ c
 c     perform dynamic allocation of some local arrays
 c
       allocate (pscale(n))
-      allocate (poli(npole))
+      allocate (poli(3,npole))
       allocate (field(3,npole))
       allocate (rsd(3,npole))
       allocate (zrsd(3,npole))
@@ -1807,7 +1846,7 @@ c
       call dfieldi (field,pscale)
       do i = 1, npole
          do j = 1, 3
-            uind(j,i) = polarity(i) * field(j,i)
+            uind(j,i) = polarity(j,i) * field(j,i)
          end do
       end do
 c
@@ -1829,10 +1868,10 @@ c
       polmin = 0.00000001d0
       call ufieldi (field,pscale)
       do i = 1, npole
-         poli(i) = max(polmin,polarity(i))
          do j = 1, 3
+            poli(j,i) = max(polmin,polarity(j,i))
             rsd(j,i) = field(j,i)
-            zrsd(j,i) = rsd(j,i) * poli(i)
+            zrsd(j,i) = rsd(j,i) * poli(j,i)
             conj(j,i) = zrsd(j,i)
          end do
       end do
@@ -1851,7 +1890,7 @@ c
          do i = 1, npole
             do j = 1, 3
                uind(j,i) = vec(j,i)
-               vec(j,i) = conj(j,i)/poli(i) - field(j,i)
+               vec(j,i) = conj(j,i)/poli(j,i) - field(j,i)
             end do
          end do
          a = 0.0d0
@@ -1872,7 +1911,7 @@ c
          b = 0.0d0
          do i = 1, npole
             do j = 1, 3
-               zrsd(j,i) = rsd(j,i) * poli(i)
+               zrsd(j,i) = rsd(j,i) * poli(j,i)
                b = b + rsd(j,i)*zrsd(j,i)
             end do
          end do
@@ -2575,7 +2614,7 @@ c
             do j = 1, maxval
                if (pgrp(j,i) .ne. 0)  k = j
             end do
-            write (ikey,180)  ipole(i),polarity(i),thole(i),
+            write (ikey,180)  ipole(i),polarity(1,i),thole(i),
      &                        (pgrp(j,i),j=1,k)
   180       format ('polarize',2x,i5,5x,2f11.4,2x,20i5)
          end do

--- a/source/prtprm.f
+++ b/source/prtprm.f
@@ -986,7 +986,9 @@ c     atomic dipole polarizability parameters
 c
       exist = .false.
       do i = 1, maxtyp
-         if (polr(i) .ne. 0.0d0)  exist = .true.
+         do j = 1, 3
+            if (polr(j,i) .ne. 0.0d0)  exist = .true.
+         end do
       end do
       if (exist) then
          write (itxt,1350)  formfeed,forcefield
@@ -997,17 +999,19 @@ c
      &              6x,'Group Atom Types',/)
          k = 0
          do i = 1, maxtyp
-            if (polr(i) .ne. 0.0d0) then
+            if (polr(1,i) .ne. 0.0d0 .or.
+     &          polr(2,i) .ne. 0.0d0 .or.
+     &          polr(3,i) .ne. 0.0d0) then
                k = k + 1
                npg = 0
                do j = 1, maxval
                   if (pgrp(j,i) .ne. 0)  npg = npg + 1
                end do
                if (npg .eq. 0) then
-                  write (itxt,1370)  k,i,polr(i),athl(i)
+                  write (itxt,1370)  k,i,polr(1,i),athl(i)
  1370             format (10x,i5,7x,i4,3x,2f10.3)
                else
-                  write (itxt,1380)  k,i,polr(i),athl(i),
+                  write (itxt,1380)  k,i,polr(1,i),athl(i),
      &                               (pgrp(j,i),j=1,npg)
  1380             format (10x,i5,7x,i4,3x,2f10.3,4x,6i5)
                end if

--- a/source/readprm.f
+++ b/source/readprm.f
@@ -75,7 +75,7 @@ c
       real*8 an,pr,ds,dk
       real*8 vd,cg,dp,ps
       real*8 fc,bd,dl,el
-      real*8 pt,pol,thl
+      real*8 pt,pol,thl,apol(3)
       real*8 iz,rp,ss,ts
       real*8 abc,cba
       real*8 gi,alphi
@@ -1175,7 +1175,35 @@ c
      &                                       (pg(i),i=1,maxval)
   450       continue
             if (ia .ne. 0) then
-               polr(ia) = pol
+               do j = 1, 3
+                  polr(j,ia) = pol
+               end do
+               athl(ia) = thl
+               do i = 1, maxval
+                  pgrp(i,ia) = pg(i)
+               end do
+            end if
+
+c
+c     anisotropic atomic dipole polarizability parameters
+c
+         else if (keyword(1:9) .eq. 'APOLARIZE') then
+            ia = 0
+            do i = 1, 3
+                apol(i) = 0.0d0
+            end do
+            thl = 0.0d0
+            do i = 1, maxval
+               pg(i) = 0
+            end do
+            string = record(next:240)
+            read (string,*,err=455,end=455)  ia,apol(1),apol(2),apol(3),
+     &                                       thl,(pg(i),i=1,maxval)
+  455       continue
+            if (ia .ne. 0) then
+               do j = 1, 3
+                  polr(j,ia) = apol(j)
+               end do
                athl(ia) = thl
                do i = 1, maxval
                   pgrp(i,ia) = pg(i)

--- a/source/rotpole.f
+++ b/source/rotpole.f
@@ -29,6 +29,7 @@ c
       do i = 1, npole
          call rotmat (i,a)
          call rotsite (i,a)
+         call rotalpha (i,a)
       end do
       return
       end
@@ -248,6 +249,50 @@ c
       a(1,2) = a(3,1)*a(2,3) - a(2,1)*a(3,3)
       a(2,2) = a(1,1)*a(3,3) - a(3,1)*a(1,3)
       a(3,2) = a(2,1)*a(1,3) - a(1,1)*a(2,3)
+      return
+      end
+c
+c
+c     #######################################################################
+c     ##                                                                   ##
+c     ##  subroutine rotalpha  --  rotate polarizabilities at single site  ##
+c     ##                                                                   ##
+c     #######################################################################
+c
+c
+c     "rotalpha" computes the atomic polarizabilities at a specified site
+c     in the global coordinate frame by applying a rotation matrix
+c
+c
+      subroutine rotalpha (isite,a)
+      use sizes
+      use atoms
+      use mpole
+      use polar
+      implicit none
+      integer i,j,k
+      integer isite
+      real*8 a(3,3),val,valinv,kpol
+      real*8 polmin
+
+      polmin = 0.00000001d0
+c
+c     rotate the polarizability to the global coordinate frame
+c
+
+      do i = 1, 3
+         do j = 1, 3
+            val = 0.0d0
+            valinv = 0.0d0
+            do k = 1, 3
+               kpol = max(polmin,polarity(k,isite))
+               val = val + a(i,k)*a(j,k)*kpol
+               valinv = valinv + a(i,k)*a(j,k)/kpol
+            end do
+            rpolarity(i,j,isite) = val
+            rpolarityinv(i,j,isite) = valinv
+         end do
+      end do
       return
       end
 c

--- a/source/xtalfit.f
+++ b/source/xtalfit.f
@@ -549,7 +549,7 @@ c
             if (mode .eq. 'STORE') then
                do i = 1, npole
                   if (type(ipole(i)) .eq. atom1) then
-                     xx(j) = polarity(i)
+                     xx(j) = polarity(1,i)
                      goto 10
                   end if
                end do
@@ -557,7 +557,7 @@ c
                sixth = 1.0d0 / 6.0d0
                do i = 1, npole
                   if (type(ipole(i)) .eq. atom1) then
-                     polarity(i) = xx(j)
+                     polarity(1,i) = xx(j)
                      if (thole(i) .ne. 0.0d0)  pdamp(i) = xx(j)**sixth
                   end if
                end do


### PR DESCRIPTION
This PR adds anisotropic polarizabilities that @JoshRackers and I worked on during his visit.  Note that it also contains the fix described in #33, so that I could test the changes.  I have not addressed OPT yet, because this is already quite a large patch.  Once merged (or ignored if you don't want this feature) I can address OPT and fix the long-standing virial bug.  The current implementation assumes that the permanent multipole axes also define the anisotropy orientations.  Implicit to this is the fact that the permanent moment axes are chosen as the natural axes (*i.e.* those that diagonalize the polarizability tensor) because we only receive *xx*, *yy* and *zz* components from the user.  Generalization to arbitrary tensors would be very trivial.  The input mechanism currently looks like:
```
apolarize   atom_type Axx Ayy Azz thole_damping groups
```
For example, the water oxygen (with fictitious parameters) would look something like:
```
apolarize    36 0.8370 0.0370  0.7370 0.3900 37
```
