### PR TITLE
improvements in Tinker-OpenMM interface & shakeup

### DIFF
--- a/openmm/ommstuff.cpp
+++ b/openmm/ommstuff.cpp
@@ -3457,7 +3457,8 @@ static void setupDistanceRestraints (OpenMM_System* system, FILE* log) {
       OpenMM_IntArray_destroy(particles);
       OpenMM_DoubleArray_destroy(distanceParameters);
    }
-   OpenMM_System_addForce(system, (OpenMM_Force*) force);
+   OpenMM_CustomCompoundBondForce_setUsesPeriodicBoundaryConditions (force, OpenMM_True);
+   OpenMM_System_addForce (system, (OpenMM_Force*) force);
 }
 
 static void setupAngleRestraints (OpenMM_System* system, FILE* log) {
@@ -3588,7 +3589,8 @@ static void setupCentroidRestraints (OpenMM_System* system, FILE* log) {
       OpenMM_IntArray_destroy (bondGroups);
       OpenMM_DoubleArray_destroy (bondParameters);
    }
-   OpenMM_System_addForce(system, (OpenMM_Force*) force);
+   OpenMM_CustomCentroidBondForce_setUsesPeriodicBoundaryConditions (force, OpenMM_True);
+   OpenMM_System_addForce (system, (OpenMM_Force*) force);
 }
 
 /*
@@ -4287,7 +4289,7 @@ void openmm_update_ (void** omm, double* dt, int* istep,
          mdstat_ (istep,dt,&totalEnergy,&potentialEnergy,&eksum,&temp,&pres);
       }
       if (*callMdSave) {
-         // bounds_ ();
+         bounds_ ();
          mdsave_ (istep,dt,&potentialEnergy,&eksum);
       }
    }

--- a/source/shakeup.f
+++ b/source/shakeup.f
@@ -53,11 +53,13 @@ c
 c
 c     perform dynamic allocation of some global arrays
 c
-      allocate (iratx(maxatm))
-      allocate (kratx(maxatm))
-      allocate (irat(2,maxatm))
-      allocate (krat(maxatm))
-      allocate (ratimage(maxatm))
+      if (.not. allocated(iratx)) then
+         allocate (iratx(maxatm))
+         allocate (kratx(maxatm))
+         allocate (irat(2,maxatm))
+         allocate (krat(maxatm))
+         allocate (ratimage(maxatm))
+      end if
 c
 c     process keywords containing holonomic constraint options
 c


### PR DESCRIPTION
1. In Tinker-OpenMM interface, the periodic boundary conditions
are enabled for distance and group restraints.

2. Add if checks for some global "allocatables" in shakeup routine,
letting mechanic routine can be called multiple times in a program.