### PR TITLE
Add a subroutine that computes the numeric version of echarge2c

### DIFF
--- a/source/echarge2.f
+++ b/source/echarge2.f
@@ -28,8 +28,8 @@ c
       if (use_smooth) then
          call echarge2d (i)
       else if (use_ewald) then
-c         call num_echarge2c (i)
-         call echarge2c (i)
+         call num_echarge2c (i)
+c         call echarge2c (i)
       else if (use_clist) then
          call echarge2b (i)
       else

--- a/source/echarge2.f
+++ b/source/echarge2.f
@@ -28,8 +28,8 @@ c
       if (use_smooth) then
          call echarge2d (i)
       else if (use_ewald) then
-         call num_echarge2c (i)
-c         call echarge2c (i)
+c         call num_echarge2c (i)
+         call echarge2c (i)
       else if (use_clist) then
          call echarge2b (i)
       else


### PR DESCRIPTION
We found that the analytical version of echarge2c produced large negative wavenumbers in the vibrate binary for specific crystal systems. Despite the crystals being thoroughly minimized we were unable to reduce the size of the wavenumbers. Additionally, computation of the wavenumbers using the testhess binary produced different wavenumbers than the vibrate binary; the testhess binary produced physically meaningful results (no negative wavenumbers).
The code of echarge2c specifically states:
https://github.com/TinkerTools/Tinker/blob/3aaf64817c4ca88a51f4800d1e5393037ea207ba/source/echarge2.f#L585-L586

To circumvent the issue, we wrote a numerical version of echarge2c subroutine that was modelled after the testhess, empolar2, and epolar2 subroutines.

I have verified that the results produced from this change are more similar between the vibrate and testhess binaries for our systems, than previously seen.

I have also made sure these changes work (ie. do not cause segmentation fault) for the timer, testhess, and vibrate binaries.

Attached is a .zip file containing a particular problematic crystal system that we used for testing.

[crystal_stystem.zip](https://github.com/TinkerTools/Tinker/files/3331061/crystal_stystem.zip)