### PR TITLE
bug fix in charge flux chain rule term

### DIFF
--- a/make/Makefile
+++ b/make/Makefile
@@ -1656,7 +1656,7 @@ cspline.o: iounit.o
 ctrpot.o:
 cutoffs.o: atoms.o bound.o hescut.o keys.o limits.o neigh.o polpot.o tarray.o
 damping.o: ewald.o math.o mplpot.o polar.o
-dcflux.o: angbnd.o atoms.o bndstr.o bound.o cflux.o mutant.o sizes.o
+dcflux.o: angbnd.o atomid.o atoms.o bndstr.o bound.o couple.o cflux.o mutant.o sizes.o
 deflate.o: iounit.o
 delete.o: atomid.o atoms.o couple.o inform.o iounit.o
 deriv.o:


### PR DESCRIPTION
Hi @jayponder , the current implementation of `bndcflux priority` is only in the `alterchg.f`, where the value could be 1, 0, and -1 for a bond. It turns out this should also be in chain rule term (`dcflux.f`). Fortunately, for water, it is coincidently correct because we have water coordinate in O H H order., where the `priority` value of two O-H bonds is 1. 

This will fix other molecules and H-H-O water. 