### PR TITLE
Add Tinker-OpenMM CMake module and improve CMake build instructions

### DIFF
--- a/cmake/0README
+++ b/cmake/0README
@@ -29,3 +29,19 @@
              (3) cmake ../cmake
              (4) make -j4    [replace 4 with # of processes to use]
              (5) make install
+
+      A CMake module is included here to facilitate building Tinker with
+      OpenMM libraries and CUDA. To turn on this capability, use the flag
+      "-DTINKER_OPENMM=ON". This will try to find the OpenMM libraries
+      in the default location (/usr/local/openmm) or in the location set
+      by the environment variable OPENMM_PLUGIN_DIR or by passing the flag
+      "-DOPENMM_DIR=/path/to/openmm". You do not need to build the base
+      version of Tinker first, these steps will compile it automatically.
+
+      To build Tinker with OpenMM libraries, issue the following commands:
+
+             (1) cd Tinker   [i.e., the top-level directory]
+             (2) mkdir build && cd build
+             (3) cmake ../cmake -DTINKER_OPENMM=ON -DOPENMM_DIR=/path/to/openmm
+             (4) make -j4    [replace 4 with # of processes to use]
+             (5) make install

--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -1,20 +1,4 @@
-cmake_minimum_required(VERSION 3.6)
-
-project(tinker VERSION 8.8.2 LANGUAGES Fortran)
-
-include(GNUInstallDirs)
-
-set(CMAKE_Fortran_MODULE_DIRECTORY ${CMAKE_BINARY_DIR}/mod)
-
-# make sure that the default is a RELEASE
-
-if(NOT CMAKE_BUILD_TYPE)
-    set(
-        CMAKE_BUILD_TYPE RELEASE CACHE STRING
-        "Choose the Type of Build, Options are: None Debug Release"
-        FORCE
-    )
-endif()
+cmake_minimum_required(VERSION 3.9)
 
 # Determine main Tinker directory
 
@@ -25,6 +9,28 @@ find_path(
     DOC "Main Tinker directory"
     REQUIRED
 )
+
+# Get the version number from the banner file
+
+file(READ "${TINKER_DIR}/source/promo.f" PROMO_F)
+string(REGEX MATCH "Version (([0-9]+)(\\.[0-9]+)*)" _ ${PROMO_F})
+set(VERSION ${CMAKE_MATCH_1})
+
+project(tinker VERSION ${VERSION} LANGUAGES Fortran)
+
+include(GNUInstallDirs)
+
+set(CMAKE_Fortran_MODULE_DIRECTORY ${CMAKE_BINARY_DIR}/mod)
+
+# Make sure that the default is a RELEASE
+
+if(NOT CMAKE_BUILD_TYPE)
+    set(
+        CMAKE_BUILD_TYPE RELEASE CACHE STRING
+        "Choose the Type of Build, Options are: None Debug Release"
+        FORCE
+    )
+endif()
 
 # Find required libraries
 
@@ -55,6 +61,11 @@ else()
     message(STATUS "Found FFTW3: ${FFTW_LIB}")
     message(STATUS "Found threaded FFTW3: ${FFTW_THREADED_LIB}")
 endif()
+
+# Link libraries automatically so that LD_LIBRARY_PATH does not need to be set
+
+set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib")
+set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
 
 # Set compiler flags
 

--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -63,7 +63,6 @@ else()
 endif()
 
 # Link libraries automatically so that LD_LIBRARY_PATH does not need to be set
-
 set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib")
 set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
 
@@ -188,3 +187,11 @@ foreach(_BIN IN LISTS _BINS)
         RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
     )
 endforeach()
+
+# Build and 
+
+set(TINKER_OPENMM OFF CACHE BOOL "Build Tinker with OpenMM")
+
+if(TINKER_OPENMM)
+    include(${TINKER_DIR}/cmake/TinkerOpenMM.cmake)
+endif()

--- a/cmake/TinkerOpenMM.cmake
+++ b/cmake/TinkerOpenMM.cmake
@@ -1,0 +1,75 @@
+enable_language(CUDA)
+enable_language(CXX)
+
+# Find OpenMM Libraries
+
+set(OPENMM_DIR /usr/local/openmm CACHE PATH "Directory of OpenMM libraries.")
+
+if(DEFINED ENV{OPENMM_PLUGIN_DIR})
+    get_filename_component(OPENMM_DIR "$ENV{OPENMM_PLUGIN_DIR}/../../" ABSOLUTE)
+else()
+    message(WARNING "Ensure that the environment variable OPENMM_PLUGIN_DIR is set before running Tinker-OpenMM.")
+endif()
+
+find_library(OPENMM_LIBRARY NAMES libOpenMM.so OpenMM HINTS ${OPENMM_DIR}/lib REQUIRED)
+find_library(OPENMM_AMOEBA_LIBRARY NAMES libOpenMMAmoeba.so OpenMMAmoeba HINTS ${OPENMM_DIR}/lib REQUIRED)
+include_directories(${OPENMM_DIR}/include)
+
+# Build Tinker's OpenMM library
+
+set(OPENMM_FILES
+    gpu_cards.cu
+    kopenmm.f
+    ommdata.f
+    ommstuf.cpp
+    openmm.f
+)
+
+set(_LIB "")
+foreach(_FILE IN LISTS OPENMM_FILES)
+    list(APPEND _LIB ${TINKER_DIR}/openmm/${_FILE})
+endforeach()
+
+add_library(tinker_omm STATIC ${_LIB})
+target_link_libraries(
+    tinker_omm
+    tinker
+    OpenMP::OpenMP_Fortran
+    ${FFTW_LIB} ${FFTW_THREADED_LIB}
+    ${CUDA_LIBRARIES}
+    ${OPENMM_LIBRARY} ${OPENMM_AMOEBA_LIBRARY}
+    cuda
+    nvidia-ml
+)
+
+install(
+    TARGETS tinker_omm
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}
+)
+
+# Build Tinker's OpenMM executables
+
+set(OPENMM_BINS
+    analyze_omm
+    bar_omm
+    dynamic_omm
+)
+
+foreach(_BIN IN LISTS OPENMM_BINS)
+    add_executable(${_BIN} ${TINKER_DIR}/openmm/${_BIN}.f)
+    set_property(TARGET ${_BIN} PROPERTY LINKER_LANGUAGE Fortran)
+    target_link_libraries(
+        ${_BIN}
+        tinker tinker_omm
+        OpenMP::OpenMP_Fortran
+        ${FFTW_LIB} ${FFTW_THREADED_LIB}
+        ${CUDA_LIBRARIES}
+        ${OPENMM_LIBRARY} ${OPENMM_AMOEBA_LIBRARY}
+        cuda
+        nvidia-ml
+    )
+    install(
+        TARGETS ${_BIN}
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+    )
+endforeach()


### PR DESCRIPTION
- CMake minimum set to 3.9 to find/link OpenMP properly
- Version is now extracted from the promo.f file to update automatically
- By setting the RPATH variables, the user does not have to set `LD_LIBRARY_PATH` to link to the proper libraries
- CMake module for Tinker-OpenMM allows easy building and linking to OpenMM libraries