### PR TITLE
angcflux parameter read and assign

### DIFF
--- a/source/kchgflx.f
+++ b/source/kchgflx.f
@@ -144,6 +144,17 @@ c
                   cfla(2,j) = cfa2
                   cflab(1,j) = cfb1
                   cflab(2,j) = cfb2
+                  if (ia .le. ic) then
+                     cfla(1,j) = cfa1
+                     cfla(2,j) = cfa2
+                     cflab(1,j) = cfb1
+                     cflab(2,j) = cfb2
+                  else
+                     cfla(1,j) = cfa2
+                     cfla(2,j) = cfa1
+                     cflab(1,j) = cfb2
+                     cflab(2,j) = cfb1
+                  end if
                   goto 90
                end if
             end do

--- a/source/kchgflx.f
+++ b/source/kchgflx.f
@@ -139,11 +139,6 @@ c
             end if
             do j = 1, maxncfa
                if (kcfa(j).eq.blank12 .or. kcfa(j).eq.pt3) then
-                  kcfa(j) = pt3
-                  cfla(1,j) = cfa1
-                  cfla(2,j) = cfa2
-                  cflab(1,j) = cfb1
-                  cflab(2,j) = cfb2
                   if (ia .le. ic) then
                      cfla(1,j) = cfa1
                      cfla(2,j) = cfa2

--- a/source/readprm.f
+++ b/source/readprm.f
@@ -1358,7 +1358,6 @@ c
             call numeral (ib,pb,size)
             call numeral (ic,pc,size)
             ncfa = ncfa + 1
-            
             if (ia .le. ic) then
                kcfa(ncfa) = pa//pb//pc
                cfla(1,ncfa) = cfa1

--- a/source/readprm.f
+++ b/source/readprm.f
@@ -1358,15 +1358,20 @@ c
             call numeral (ib,pb,size)
             call numeral (ic,pc,size)
             ncfa = ncfa + 1
+            
             if (ia .le. ic) then
                kcfa(ncfa) = pa//pb//pc
+               cfla(1,ncfa) = cfa1
+               cfla(2,ncfa) = cfa2
+               cflab(1,ncfa) = cfb1
+               cflab(2,ncfa) = cfb2
             else
                kcfa(ncfa) = pc//pb//pa
+               cfla(1,ncfa) = cfa2
+               cfla(2,ncfa) = cfa1
+               cflab(1,ncfa) = cfb2
+               cflab(2,ncfa) = cfb1
             end if
-            cfla(1,ncfa) = cfa1
-            cfla(2,ncfa) = cfa2
-            cflab(1,ncfa) = cfb1
-            cflab(2,ncfa) = cfb2
 c
 c     implicit solvation parameters
 c


### PR DESCRIPTION
Hi Jay, 
We think the angle-cflux parameters need flip (`jtheta1` and `jtheta2`, `jbp1` and `jbp2`) when atom class numbers `ia` greater than `ic`. Hope you can think about this issue again before agreeing to merge my changes. 
Thanks,
Chengwen

