### PR TITLE
Exch ind

### DIFF
--- a/source/alterpol.f
+++ b/source/alterpol.f
@@ -65,6 +65,7 @@ c
       integer i,j,k,m
       integer ii,kk
       integer jcell
+      real*8 xi,yi,zi
       real*8 xr,yr,zr
       real*8 r,r2,r3,r4,r5
       real*8 sizi,sizk,sizik
@@ -117,6 +118,9 @@ c     find variable polarizability scale matrix at each site
 c
       do ii = 1, npole-1
          i = ipole(ii)
+         xi = x(i)
+         yi = y(i)
+         zi = z(i)
          springi = kpep(ii)
          sizi = prepep(ii)
          alphai = dmppep(ii)
@@ -159,9 +163,9 @@ c
             k = ipole(kk)
             eplk = lpep(kk)
             if (epli .or. eplk) then
-               xr = x(k) - x(i)
-               yr = y(k) - y(i)
-               zr = z(k) - z(i)
+               xr = x(k) - xi
+               yr = y(k) - yi
+               zr = z(k) - zi
                if (use_bounds)  call image (xr,yr,zr)
                r2 = xr*xr + yr*yr + zr*zr
                if (r2 .le. off2) then
@@ -220,6 +224,9 @@ c     calculate interaction energy with other unit cells
 c
          do ii = 1, npole
             i = ipole(ii)
+            xi = x(i)
+            yi = y(i)
+            zi = z(i)
             springi = kpep(ii)
             sizi = prepep(ii)
             alphai = dmppep(ii)
@@ -263,9 +270,9 @@ c
                eplk = lpep(kk)
                if (epli .or. eplk) then
                   do jcell = 2, ncell
-                     xr = x(k) - x(i)
-                     yr = y(k) - y(i)
-                     zr = z(k) - z(i)
+                     xr = x(k) - xi
+                     yr = y(k) - yi
+                     zr = z(k) - zi
                      call imager (xr,yr,zr,jcell)
                      r2 = xr*xr + yr*yr + zr*zr
                      if (r2 .le. off2) then
@@ -366,6 +373,7 @@ c
       implicit none
       integer i,j,k,m
       integer ii,kk,kkk
+      real*8 xi,yi,zi
       real*8 xr,yr,zr
       real*8 r,r2,r3,r4,r5
       real*8 sizi,sizk,sizik
@@ -429,6 +437,9 @@ c     find the variable polarizability
 c
       do ii = 1, npole
          i = ipole(ii)
+         xi = x(i)
+         yi = y(i)
+         zi = z(i)
          springi = kpep(ii)
          sizi = prepep(ii)
          alphai = dmppep(ii)
@@ -472,9 +483,9 @@ c
             k = ipole(kk)
             eplk = lpep(kk)
             if (epli .or. eplk) then
-               xr = x(k) - x(i)
-               yr = y(k) - y(i)
-               zr = z(k) - z(i)
+               xr = x(k) - xi
+               yr = y(k) - yi
+               zr = z(k) - zi
                if (use_bounds)  call image (xr,yr,zr)
                r2 = xr*xr + yr*yr + zr*zr
                if (r2 .le. off2) then

--- a/source/alterpol.f
+++ b/source/alterpol.f
@@ -101,15 +101,6 @@ c
          polscale(1,3,i) = 0.0d0
          polscale(2,3,i) = 0.0d0
          polscale(3,3,i) = 1.0d0
-         polinv(1,1,i) = 1.0d0
-         polinv(2,1,i) = 0.0d0
-         polinv(3,1,i) = 0.0d0
-         polinv(1,2,i) = 0.0d0
-         polinv(2,2,i) = 1.0d0
-         polinv(3,2,i) = 0.0d0
-         polinv(1,3,i) = 0.0d0
-         polinv(2,3,i) = 0.0d0
-         polinv(3,3,i) = 1.0d0
       end do
 c
 c     set array needed to scale atom and group interactions

--- a/source/damping.f
+++ b/source/damping.f
@@ -915,7 +915,7 @@ c     "dampexpl" finds the overlap value for exchange polarization
 c     damping function
 c
 c
-      subroutine dampexpl (r,preik,alphai,alphak,s2,ds2)
+      subroutine dampexpl (r,preik,alphai,alphak,s2,ds2,do_g)
       use polpot
       implicit none
       real*8 r,s,s2,ds2
@@ -929,6 +929,7 @@ c
       real*8 expi,expk,expik
       real*8 dampi,dampk,dampi2
       real*8 pre,term,preik
+      logical do_g
 c
 c
       if (scrtyp .eq. 'S2U') then
@@ -939,7 +940,8 @@ c
          expik = exp(-dampik)
          s =(1+dampik+dampik2/3.0d0)*expik
          s2 = s*s
-         ds2 = s * (-alphaik/3.0d0)*(dampik+dampik2)*expik
+         if (do_g)
+     &      ds2 = s * (-alphaik/3.0d0)*(dampik+dampik2)*expik
 c
 c     compute tolerance value for overlap-based damping
 c
@@ -955,7 +957,8 @@ c
             dampi2 = dampi * dampi
             expi = exp(-dampi)
             s = (1+dampi+dampi2/3.0d0)*expi
-            ds2 = s * (-alphai/3.0d0)*(dampi+dampi2)*expi
+            if (do_g)
+     &         ds2 = s * (-alphai/3.0d0)*(dampi+dampi2)*expi
 c
 c     treat the case where alpha damping exponents are unequal
 c
@@ -972,9 +975,10 @@ c
             pre = sqrt(alphai**3 * alphak**3) / (r * term**3)
             s = pre*(dmpi2*(r*term - 4*dmpk2) * expk
      &            + dmpk2*(r*term + 4*dmpi2) * expi)
-            ds2 = 2.0d0*s*pre*dmpi2*dmpk2 *
-     &       ((4.0d0/r-(r*term-4.0d0*dmpk2))*expk -
-     &       ((4.0d0/r+(r*term+4.0d0*dmpi2))*expi))
+            if (do_g)
+     &         ds2 = 2.0d0*s*pre*dmpi2*dmpk2 *
+     &          ((4.0d0/r-(r*term-4.0d0*dmpk2))*expk -
+     &          ((4.0d0/r+(r*term+4.0d0*dmpi2))*expi))
          end if
          s2 = s*s
 c
@@ -983,9 +987,11 @@ c
       else if (scrtyp .eq. 'G  ') then
          alphaik = sqrt(alphai * alphak)
          s2 = exp(-alphaik/10.0d0 * r**2)
-         ds2 = (-alphaik/5.0d0)*r*s2
+         if (do_g)
+     &      ds2 = (-alphaik/5.0d0)*r*s2
       end if
       s2 = preik*s2
-      ds2 = preik*ds2
+      if (do_g)
+     &   ds2 = preik*ds2
       return
       end

--- a/source/dexpol.f
+++ b/source/dexpol.f
@@ -69,6 +69,7 @@ c
       integer i,j,k
       integer ii,kk
       integer jcell
+      real*8 xi,yi,zi
       real*8 xr,yr,zr
       real*8 r,r2,r3,r4,r5
       real*8 sizi,sizk,sizik
@@ -78,6 +79,8 @@ c
       real*8 s2i,s2k
       real*8 ds2i,ds2k
       real*8 taper,dtaper
+      real*8 uix,uiy,uiz
+      real*8 ukx,uky,ukz
       real*8 uixl,ukxl
       real*8 uiyl,ukyl
       real*8 uizl,ukzl
@@ -121,10 +124,16 @@ c     find the exchange polarization gradient
 c
       do ii = 1, npole-1
          i = ipole(ii)
+         xi = x(i)
+         yi = y(i)
+         zi = z(i)
          springi = kpep(ii) / polarity(ii)
          sizi = prepep(ii)
          alphai = dmppep(ii)
          epli = lpep(ii)
+         uix = uind(1,ii)
+         uiy = uind(2,ii)
+         uiz = uind(3,ii)
 c
 c     set exclusion coefficients for connected atoms
 c
@@ -163,9 +172,9 @@ c
             k = ipole(kk)
             eplk = lpep(kk)
             if (epli .or. eplk) then
-               xr = x(k) - x(i)
-               yr = y(k) - y(i)
-               zr = z(k) - z(i)
+               xr = x(k) - xi
+               yr = y(k) - yi
+               zr = z(k) - zi
                if (use_bounds)  call image (xr,yr,zr)
                r2 = xr*xr + yr*yr + zr*zr
                if (r2 .le. off2) then
@@ -174,6 +183,9 @@ c
                   sizk = prepep(kk)
                   alphak = dmppep(kk)
                   sizik = sizi * sizk
+                  ukx = uind(1,kk)
+                  uky = uind(2,kk)
+                  ukz = uind(3,kk)
                   call dampexpl (r,sizik,alphai,alphak,s2,ds2,do_g)
 c
 c     use energy switching if near the cutoff distance
@@ -194,20 +206,12 @@ c
                   ds2i = springi * ds2 * pscale(k)
                   ds2k = springk * ds2 * pscale(k)
                   call rotdexpl (r,xr,yr,zr,ai,ak)
-                  uixl = 0.0d0
-                  ukxl = 0.0d0
-                  uiyl = 0.0d0
-                  ukyl = 0.0d0
-                  uizl = 0.0d0
-                  ukzl = 0.0d0
-                  do j = 1, 3
-                     uixl = uixl + uind(j,ii)*ai(1,j)
-                     ukxl = ukxl - uind(j,kk)*ak(1,j)
-                     uiyl = uiyl + uind(j,ii)*ai(2,j)
-                     ukyl = ukyl - uind(j,kk)*ak(2,j)
-                     uizl = uizl + uind(j,ii)*ai(3,j)
-                     ukzl = ukzl - uind(j,kk)*ak(3,j)
-                  end do
+                  uixl = uix*ai(1,1) + uiy*ai(1,2) + uiz*ai(1,3)
+                  uiyl = uix*ai(2,1) + uiy*ai(2,2) + uiz*ai(2,3)
+                  uizl = uix*ai(3,1) + uiy*ai(3,2) + uiz*ai(3,3)
+                  ukxl = -(ukx*ak(1,1) + uky*ak(1,2) + ukz*ak(1,3))
+                  ukyl = -(ukx*ak(2,1) + uky*ak(2,2) + ukz*ak(2,3))
+                  ukzl = -(ukx*ak(3,1) + uky*ak(3,2) + ukz*ak(3,3))
                   frcil(3) = uizl**2 * ds2i
                   frckl(3) = ukzl**2 * ds2k
 c
@@ -300,10 +304,16 @@ c     calculate interaction components with other unit cells
 c
          do ii = 1, npole
             i = ipole(ii)
+            xi = x(i)
+            yi = y(i)
+            zi = z(i)
             springi = kpep(ii) / polarity(ii)
             sizi = prepep(ii)
             alphai = dmppep(ii)
             epli = lpep(ii)
+            uix = uind(1,ii)
+            uiy = uind(2,ii)
+            uiz = uind(3,ii)
 c
 c     set exclusion coefficients for connected atoms
 c
@@ -343,9 +353,9 @@ c
                eplk = lpep(kk)
                if (epli .or. eplk) then
                   do jcell = 2, ncell
-                     xr = x(k) - x(i)
-                     yr = y(k) - y(i)
-                     zr = z(k) - z(i)
+                     xr = x(k) - xi
+                     yr = y(k) - yi
+                     zr = z(k) - zi
                      call imager (xr,yr,zr,jcell)
                      r2 = xr*xr + yr*yr + zr*zr
                      if (r2 .le. off2) then
@@ -382,20 +392,12 @@ c
                         ds2i = springi * ds2 * pscale(k)
                         ds2k = springk * ds2 * pscale(k)
                         call rotdexpl (r,xr,yr,zr,ai,ak)
-                        uixl = 0.0d0
-                        ukxl = 0.0d0
-                        uiyl = 0.0d0
-                        ukyl = 0.0d0
-                        uizl = 0.0d0
-                        ukzl = 0.0d0
-                        do j = 1, 3
-                           uixl = uixl + uind(j,ii)*ai(1,j)
-                           ukxl = ukxl - uind(j,kk)*ak(1,j)
-                           uiyl = uiyl + uind(j,ii)*ai(2,j)
-                           ukyl = ukyl - uind(j,kk)*ak(2,j)
-                           uizl = uizl + uind(j,ii)*ai(3,j)
-                           ukzl = ukzl - uind(j,kk)*ak(3,j)
-                        end do
+                        uixl = uix*ai(1,1) + uiy*ai(1,2) + uiz*ai(1,3)
+                        uiyl = uix*ai(2,1) + uiy*ai(2,2) + uiz*ai(2,3)
+                        uizl = uix*ai(3,1) + uiy*ai(3,2) + uiz*ai(3,3)
+                        ukxl =-(ukx*ak(1,1) + uky*ak(1,2) + ukz*ak(1,3))
+                        ukyl =-(ukx*ak(2,1) + uky*ak(2,2) + ukz*ak(2,3))
+                        ukzl =-(ukx*ak(3,1) + uky*ak(3,2) + ukz*ak(3,3))
                         frcil(3) = uizl**2 * ds2i
                         frckl(3) = ukzl**2 * ds2k
 c
@@ -517,6 +519,7 @@ c
       implicit none
       integer i,j,k
       integer ii,kk,kkk
+      real*8 xi,yi,zi
       real*8 xr,yr,zr
       real*8 r,r2,r3,r4,r5
       real*8 sizi,sizk,sizik
@@ -526,6 +529,8 @@ c
       real*8 s2i, s2k
       real*8 ds2i, ds2k
       real*8 taper,dtaper
+      real*8 uix,uiy,uiz
+      real*8 ukx,uky,ukz
       real*8 uixl,ukxl
       real*8 uiyl,ukyl
       real*8 uizl,ukzl
@@ -580,10 +585,16 @@ c     find the exchange polarization gradient
 c
       do ii = 1, npole
          i = ipole(ii)
+         xi = x(i)
+         yi = y(i)
+         zi = z(i)
          springi = kpep(ii) / polarity(ii)
          sizi = prepep(ii)
          alphai = dmppep(ii)
          epli = lpep(ii)
+         uix = uind(1,ii)
+         uiy = uind(2,ii)
+         uiz = uind(3,ii)
 c
 c     set exclusion coefficients for connected atoms
 c
@@ -623,9 +634,9 @@ c
             k = ipole(kk)
             eplk = lpep(kk)
             if (epli .or. eplk) then
-               xr = x(k) - x(i)
-               yr = y(k) - y(i)
-               zr = z(k) - z(i)
+               xr = x(k) - xi
+               yr = y(k) - yi
+               zr = z(k) - zi
                if (use_bounds)  call image (xr,yr,zr)
                r2 = xr*xr + yr*yr + zr*zr
                if (r2 .le. off2) then
@@ -654,20 +665,12 @@ c
                   ds2i = springi * ds2 * pscale(k)
                   ds2k = springk * ds2 * pscale(k)
                   call rotdexpl (r,xr,yr,zr,ai,ak)
-                  uixl = 0.0d0
-                  ukxl = 0.0d0
-                  uiyl = 0.0d0
-                  ukyl = 0.0d0
-                  uizl = 0.0d0
-                  ukzl = 0.0d0
-                  do j = 1, 3
-                     uixl = uixl + uind(j,ii)*ai(1,j)
-                     ukxl = ukxl - uind(j,kk)*ak(1,j)
-                     uiyl = uiyl + uind(j,ii)*ai(2,j)
-                     ukyl = ukyl - uind(j,kk)*ak(2,j)
-                     uizl = uizl + uind(j,ii)*ai(3,j)
-                     ukzl = ukzl - uind(j,kk)*ak(3,j)
-                  end do
+                  uixl = uix*ai(1,1) + uiy*ai(1,2) + uiz*ai(1,3)
+                  uiyl = uix*ai(2,1) + uiy*ai(2,2) + uiz*ai(2,3)
+                  uizl = uix*ai(3,1) + uiy*ai(3,2) + uiz*ai(3,3)
+                  ukxl = -(ukx*ak(1,1) + uky*ak(1,2) + ukz*ak(1,3))
+                  ukyl = -(ukx*ak(2,1) + uky*ak(2,2) + ukz*ak(2,3))
+                  ukzl = -(ukx*ak(3,1) + uky*ak(3,2) + ukz*ak(3,3))
                   frcil(3) = uizl**2 * ds2i
                   frckl(3) = ukzl**2 * ds2k
 c

--- a/source/dexpol.f
+++ b/source/dexpol.f
@@ -781,6 +781,7 @@ c
       real*8 xr,yr,zr
       real*8 r,dot,eps
       real*8 dx,dy,dz
+      real*8 dr
       real*8 ai(3,3)
       real*8 ak(3,3)
 c
@@ -803,13 +804,13 @@ c
       dx = dx - dot*ai(3,1)
       dy = dy - dot*ai(3,2)
       dz = dz - dot*ai(3,3)
-      r = sqrt(dx*dx + dy*dy + dz*dz)
+      dr = sqrt(dx*dx + dy*dy + dz*dz)
 c
 c     matrix "ai" rotates a vector from global to local frame
 c
-      ai(1,1) = dx / r
-      ai(1,2) = dy / r
-      ai(1,3) = dz / r
+      ai(1,1) = dx / dr
+      ai(1,2) = dy / dr
+      ai(1,3) = dz / dr
       ai(2,1) = ai(1,3)*ai(3,2) - ai(1,2)*ai(3,3)
       ai(2,2) = ai(1,1)*ai(3,3) - ai(1,3)*ai(3,1)
       ai(2,3) = ai(1,2)*ai(3,1) - ai(1,1)*ai(3,2)

--- a/source/induce.f
+++ b/source/induce.f
@@ -370,10 +370,10 @@ c
      &                            - uind(3,i)*polscale(j,3,i))/poli(i)
      &                                 + field(j,i)
                         rsdp(j,i) = (udirp(j,i)
-     &                            - uinp(1,i)*polscale(j,1,i)
-     &                            - uinp(2,i)*polscale(j,2,i)
-     &                            - uinp(3,i)*polscale(j,3,i))/poli(i)
-     &                                 + fieldp(j,i)
+     &                            -  uinp(1,i)*polscale(j,1,i)
+     &                            -  uinp(2,i)*polscale(j,2,i)
+     &                            -  uinp(3,i)*polscale(j,3,i))/poli(i)
+     &                                  + fieldp(j,i)
                      else
 	                     rsd(j,i) = (udir(j,i)-uind(j,i))/poli(i)
      &                                 + field(j,i)
@@ -455,7 +455,6 @@ c
                      uind(j,i) = vec(j,i)
                      uinp(j,i) = vecp(j,i)
                      if (use_expol) then
-                     
                         vec(j,i) = (conj(1,i)*polscale(j,1,i)
      &                            + conj(2,i)*polscale(j,2,i)
      &                            + conj(3,i)*polscale(j,3,i))/poli(i)


### PR DESCRIPTION
Cleaned up routines related to exchpol:
1. alterpol.f - matrix inversion only done for elements that are used.
2. damping.f - derivative not computed for energy calculations.
3. dexpol.f - parts of code moved from the inner loop to outer loop, matrix inversion only done for elements that are used.
4. induce.f - removed confusing expoli array.