### PR TITLE
script-based build: add extfld and exfield

### DIFF
--- a/linux/gfortran/compile.make
+++ b/linux/gfortran/compile.make
@@ -51,6 +51,7 @@ gfortran -c -Ofast -mavx -fopenmp dsppot.f
 gfortran -c -Ofast -mavx -fopenmp energi.f
 gfortran -c -Ofast -mavx -fopenmp ewald.f
 gfortran -c -Ofast -mavx -fopenmp expol.f
+gfortran -c -Ofast -mavx -fopenmp extfld.f
 gfortran -c -Ofast -mavx -fopenmp faces.f
 gfortran -c -Ofast -mavx -fopenmp fft.f
 gfortran -c -Ofast -mavx -fopenmp fields.f
@@ -363,6 +364,7 @@ gfortran -c -Ofast -mavx -fopenmp eurey1.f
 gfortran -c -Ofast -mavx -fopenmp eurey2.f
 gfortran -c -Ofast -mavx -fopenmp eurey3.f
 gfortran -c -Ofast -mavx -fopenmp evcorr.f
+gfortran -c -Ofast -mavx -fopenmp exfield.f
 gfortran -c -Ofast -mavx -fopenmp extra.f
 gfortran -c -Ofast -mavx -fopenmp extra1.f
 gfortran -c -Ofast -mavx -fopenmp extra2.f

--- a/linux/gfortran/library.make
+++ b/linux/gfortran/library.make
@@ -211,7 +211,9 @@ eurey2.o \
 eurey3.o \
 evcorr.o \
 ewald.o \
+exfield.o \
 expol.o \
+extfld.o \
 extra.o \
 extra1.o \
 extra2.o \


### PR DESCRIPTION
Using the build scripts `compile.make`, `library.make` and `link.make` currently fails because `extfld.f` and `exfield.f` are not built and not included in the library. This PR includes adds both files to the corresponding scripts.