### PR TITLE
Feature/print stress t25

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -144,16 +144,16 @@ set(_FILES
     params paths pbstuf pdb phipsi picalc piorbs pistuf pitors pme
     pmestuf pmpb polar polgrp polopt polpcg polpot poltcg polymer potent
     potfit predict pressure prmkey promo prtarc prtdyn prterr prtfrc
-    prtint prtmol2 prtpdb prtprm prtseq prtuind prtvel prtxyz ptable
+    prtint prtmol2 prtpdb prtprm prtseq prtstres prtuind prtvel prtxyz ptable
     qmstuf qrsolve quatfit random rattle readcart readdcd readdyn
     readgau readgdma readint readmbis readmol readmol2 readpdb readprm
     readseq readxyz refer repel replica reppot resdue respa restrn rgddyn
     rgdstep richmond rigid ring rings rmsfit rotbnd rotlist rotpole
     rxnfld rxnpot scales sdstep search sequen server setprm shakeup
     shapes shunt sigmoid simplex sizes sktstuf socket solpot solute sort
-    square stodyn strbnd strtor suffix surface surfatom switch syntrn
-    tarray tcgstuf temper tettor tettors titles tncg torphase torpot
-    torque tors torsions tortor tree trimtext tritor tritors unionball
+    square stodyn strbnd stresinit strtor strvar suffix surface surfatom
+    switch syntrn tarray tcgstuf temper tettor tettors titles tncg torphase
+    torpot torque tors torsions tortor tree trimtext tritor tritors unionball
     unitcell units uprior urey urypot usage valfit vdw vdwpot verlet
     version vibs virial volume warp xtals xyzatm zatom zclose zcoord
 )

--- a/source/beeman.f
+++ b/source/beeman.f
@@ -159,6 +159,7 @@ c
 c
 c     compute statistics and save trajectory for this step
 c
+      call prtstres (istep,stress)
       call mdstat (istep,dt,etot,epot,eksum,temp,pres)
       call mdsave (istep,dt,epot,eksum)
       call mdrest (istep)

--- a/source/dynamic.f
+++ b/source/dynamic.f
@@ -227,6 +227,10 @@ c     perform the setup functions needed to run dynamics
 c
       call mdinit (dt)
 c
+c     check for keywords that alter stress tensor output
+c
+      call stresinit (dt)
+c
 c     print out a header line for the dynamics computation
 c
       if (integrate .eq. 'VERLET') then

--- a/source/prtstres.f
+++ b/source/prtstres.f
@@ -28,6 +28,7 @@ c
       integer istep
       integer istr
       integer modstre
+      integer freeunit
       real*8 stress(3,3)
       logical exist
       character*240 strfile

--- a/source/prtstres.f
+++ b/source/prtstres.f
@@ -1,0 +1,71 @@
+c
+c
+c     ###################################################
+c     ##                                               ##
+c     ##                                               ##
+c     ###################################################
+c
+c     ################################################################
+c     ##                                                            ##
+c     ##  subroutine prtstres  --  output of stress tensor          ##
+c     ##                                                            ##
+c     ################################################################
+c
+c
+c     "prtstres" writes stress tensor components to an output file
+c
+c
+      subroutine prtstres (istep,stress)
+      use bound
+      use boxes
+      use files
+      use inform
+      use iounit
+      use output
+      use strvar
+      use titles
+      implicit none
+      integer istep
+      integer istr
+      integer modstre
+      real*8 stress(3,3)
+      logical exist
+      character*240 strfile
+c
+c
+c     only necessary if user requests stress tensor output
+c
+      if (.not. stresav)  return
+c
+c     check number of steps between trajectory file saves
+c
+      modstre = mod(istep,istress)
+      if (modstre .ne. 0)  return
+c
+c     open and format the output file 
+c
+      istr = freeunit ()
+      strfile = filename(1:leng)
+      call suffix (strfile,'str','old')
+      inquire (file=strfile,exist=exist)
+      if (exist) then
+         call openend (istr,strfile)
+      else
+         open (unit=istr,file=strfile,status='new')
+         write (istr, 10)
+   10    format ('MD STEP',4x,
+     &           'STRESS(1,1)',4x,'STRESS(2,1)',4x,'STRESS(3,1)',4x,
+     &           'STRESS(1,2)',4x,'STRESS(2,2)',4x,'STRESS(3,2)',4x,
+     &           'STRESS(1,3)',4x,'STRESS(2,3)',4x,'STRESS(3,3)')
+      end if
+c
+c     write the value of the stress tensor components
+c
+      write (istr, 20) istep,stress
+   20 format (i7,9f15.4)
+c
+c     close the stress tensor output file
+c      
+      close (unit=istr)
+      return
+      end

--- a/source/stresinit.f
+++ b/source/stresinit.f
@@ -15,9 +15,6 @@ c
 c     "stresinit" checks if user requests outputting the stress tensor  
 c     and if so, how often.
 c
-c     NOTE: This is the minimum amount of code required for functionality.
-c     A future "stresinit" update could add logic to verify that correct 
-c     ensemble (NVT) and thermostat (Velocity-Scaling) are selected.
 c
 c
       subroutine stresinit (dt)
@@ -34,7 +31,7 @@ c
 c     set default values for stress tensor output variables
 c
       stresav = .false.
-      stresfrq = 10.0d0
+      istress = 10
 c
 c     search keywords for stress output parameters
 c
@@ -47,13 +44,9 @@ c
          if (keyword(1:12) .eq. 'SAVE-STRESS ') then
             stresav = .true.
          else if (keyword(1:12) .eq. 'STRESS-FREQ ') then
-            read (string,*,err=10,end=10) stresfrq
+            read (string,*,err=10,end=10) istress
          end if
    10    continue
       end do
-      if (stresav) then
-         stresfrq = 0.001d0 * stresfrq
-         istress = nint(stresfrq/dt)
-      end if
       return
       end

--- a/source/stresinit.f
+++ b/source/stresinit.f
@@ -1,0 +1,59 @@
+c
+c
+c     ###################################################
+c     ##                                               ##
+c     ##                                               ##
+c     ###################################################
+c
+c     ################################################################
+c     ##                                                            ##
+c     ##  subroutine stresinit  --  set stress tenor output         ##
+c     ##                                                            ##
+c     ################################################################
+c
+c
+c     "stresinit" checks if user requests outputting the stress tensor  
+c     and if so, how often.
+c
+c     NOTE: This is the minimum amount of code required for functionality.
+c     A future "stresinit" update could add logic to verify that correct 
+c     ensemble (NVT) and thermostat (Velocity-Scaling) are selected.
+c
+c
+      subroutine stresinit (dt)
+      use keys
+      use strvar
+      implicit none
+      integer i,next
+      real*8 dt
+      character*20 keyword
+      character*240 record
+      character*240 string
+c
+c
+c     set default values for stress tensor output variables
+c
+      stresav = .false.
+      stresfrq = 10.0d0
+c
+c     search keywords for stress output parameters
+c
+      do i = 1, nkey
+         next = 1
+         record = keyline(i)
+         call gettext (record,keyword,next)
+         call upcase (keyword)
+         string = record(next:240)
+         if (keyword(1:12) .eq. 'SAVE-STRESS ') then
+            stresav = .true.
+         else if (keyword(1:12) .eq. 'STRESS-FREQ ') then
+            read (string,*,err=10,end=10) stresfrq
+         end if
+   10    continue
+      end do
+      if (stresav) then
+         stresfrq = 0.001d0 * stresfrq
+         istress = nint(stresfrq/dt)
+      end if
+      return
+      end

--- a/source/strvar.f
+++ b/source/strvar.f
@@ -20,7 +20,6 @@ c
       module strvar
       implicit none
       integer istress
-      real*8 stresfrq
       logical stresav
       save
       end

--- a/source/strvar.f
+++ b/source/strvar.f
@@ -1,0 +1,27 @@
+c
+c
+c     ###################################################
+c     ##                                               ##
+c     ##                                               ##
+c     ###################################################
+c
+c     #################################################################
+c     ##                                                             ##
+c     ##  module strvar -- stress tensor output control parameters   ##
+c     ##                                                             ##
+c     #################################################################
+c
+c
+c     stresav   logical flag to save stress tensor components
+c     stresfrq  time (in femtoseconds) between stress tensor prints 
+c     istress   steps between stress tensor component prints   
+c
+c
+      module strvar
+      implicit none
+      integer istress
+      real*8 stresfrq
+      logical stresav
+      save
+      end
+      

--- a/source/strvar.f
+++ b/source/strvar.f
@@ -13,7 +13,6 @@ c     #################################################################
 c
 c
 c     stresav   logical flag to save stress tensor components
-c     stresfrq  time (in femtoseconds) between stress tensor prints 
 c     istress   steps between stress tensor component prints   
 c
 c

--- a/source/verlet.f
+++ b/source/verlet.f
@@ -23,6 +23,7 @@ c
       use ielscf
       use moldyn
       use polar
+      use strvar
       use units
       use usage
       implicit none
@@ -30,8 +31,9 @@ c
       integer istep
       real*8 dt,dt_2
       real*8 etot,epot
-      real*8 eksum,term
+      real*8 eksum
       real*8 temp,pres
+      real*8 term
       real*8 ekin(3,3)
       real*8 stress(3,3)
       real*8, allocatable :: xold(:)
@@ -142,6 +144,7 @@ c
 c
 c     compute statistics and save trajectory for this step
 c
+      call prtstres (istep,stress)
       call mdstat (istep,dt,etot,epot,eksum,temp,pres)
       call mdsave (istep,dt,epot,eksum)
       call mdrest (istep)


### PR DESCRIPTION
# Summary

This pull request adds functionality to output the stress tensor at user-defined intervals during molecular dynamics (MD) simulations, enabling viscosity calculations using the Green-Kubo or Einstein relations.

## Details

- Introduces two new keywords:
   - `SAVE-STRESS` controls whether the full stress tensor is written during MD simulation. 
   - `STRESS-FREQ` sets the number of MD steps between stress tensor writes.

- Outputs components to a formatted `.str` file with a single-line, 7-column layout: the MD step followed by the 6 unique stress tensor components with labeled headers.

- Adds new source files to support stress tensor output:
  - **Module** `strvar.f` defines variables for stress tensor output 
  - **Subroutine** `stresinit.f` checks for stress output request from user
  - **Subroutine** `prtstres.f` writes tensor data to `.str` file

- Updates existing source files to integrate new functionality:
  - `dynamic.f` updated to call `stresinit.f`
  - `verlet.f` updated to call `prtstres.f`
  - `beeman.f` updated to call `prtstres.f`

- Updates `CMakeLists.txt` to include new source files in the build system

## Sample Output

Appears in the `.str` file:

```
 MD Step     Stress(xx)     Stress(yy)     Stress(zz)     Stress(xy)     Stress(yz)     Stress(xz)
       5       752.4352       471.8455     -1486.1550      -553.0963       354.2783     -3115.6592
      10      -648.6845      2286.8894       561.1382       986.7980     -1678.7225     -1488.8422
      15      1237.5270       761.7150       488.3893      1241.9660       -95.4717       879.1930
      20       457.6210     -1230.6099      1084.2425      -621.4301      -130.1725      2553.5449
```

## Performance

- No significant effect on wall-clock time at 5 and 10 step print intervals.
- Adds ~14% overhead in both Tinker 8.11.4 and Tinker 25.2 with a 1 step output interval.
 
## Potential Documentation Text for Manual

**SAVE-STRESS**
Causes Tinker molecular dynamics calculations to save the values of the stress tensor components to an output file with the suffix ".str". This keyword is compatible with the velocity-verlet and beeman integrators.

**STRESS-FREQ**
Sets the number of MD steps between stress tensor prints. A default value of 10 steps is used for STRESS-FREQ in absence of the keyword. 

##  Notes

Manuscript in preparation describing these modifications and a companion toolkit for viscosity calculations.

Modifications have also been implemented in version 8.11.4. Separate branches are maintained for version compatibility.

Support for these additions has been implemented in the CMake build system. I can extend this to the Makefile-based build system if desired. Happy to adjust anything to better align with project conventions. Thanks for your time and consideration.